### PR TITLE
Add payload builder to builder-registrations.json

### DIFF
--- a/builder-registrations.json
+++ b/builder-registrations.json
@@ -38,5 +38,10 @@
         "name": "boba-builder",
         "rpc": "boba-builder.com/searcher/bundle",
         "supported-apis": ["refund-recipient"]
+    },
+    {
+        "name": "payload",
+        "rpc": "rpc.payload.de",
+        "supported-apis": ["refund-recipient"]
     }
 ]


### PR DESCRIPTION

payload.de supports fair market principles and refunds are provided with `refundPercent`/`refundRecipient` API.