### PR TITLE
Switch to refund-recipient and cancel-endpoint

### DIFF
--- a/builder-registrations.json
+++ b/builder-registrations.json
@@ -82,7 +82,7 @@
     {
         "name": "BTCS",
         "rpc": "flashbots.btcs.com",
-        "supported-apis": ["v0.1"]
+        "supported-apis": ["refund-recipient", "cancel-endpoint"]
     },
     {
         "name": "bloXroute",


### PR DESCRIPTION
We've moved away from share bundles after adding support for eth_sendBundle refunds on chain and have been using that for a while with other OFAs that require on chain refunds. 

We also have eth_cancelBundle support.