### PR TITLE
Register ethbuilder builder

### DIFF
--- a/builder-registrations.json
+++ b/builder-registrations.json
@@ -2,91 +2,141 @@
     {
         "name": "flashbots",
         "rpc": "rpc.flashbots.net",
-        "supported-apis": ["v0.1"]
+        "supported-apis": [
+            "v0.1"
+        ]
     },
     {
         "name": "f1b.io",
         "rpc": "https://rpc.f1b.io",
-        "supported-apis": ["refund-recipient"]
+        "supported-apis": [
+            "refund-recipient"
+        ]
     },
     {
         "name": "rsync",
         "rpc": "rsync-builder.xyz",
-        "supported-apis": ["refund-recipient", "cancel-endpoint"]
+        "supported-apis": [
+            "refund-recipient",
+            "cancel-endpoint"
+        ]
     },
     {
         "name": "beaverbuild.org",
         "rpc": "mevshare-rpc.beaverbuild.org",
-        "supported-apis": ["refund-recipient", "cancel-empty-bundle"]
+        "supported-apis": [
+            "refund-recipient",
+            "cancel-empty-bundle"
+        ]
     },
     {
         "name": "builder0x69",
         "rpc": "builder0x69.io",
-        "supported-apis": ["refund-recipient"]
+        "supported-apis": [
+            "refund-recipient"
+        ]
     },
     {
         "name": "Titan",
         "rpc": "rpc.titanbuilder.xyz",
-        "supported-apis": ["refund-recipient", "cancel-endpoint"]
+        "supported-apis": [
+            "refund-recipient",
+            "cancel-endpoint"
+        ]
     },
     {
         "name": "EigenPhi",
         "rpc": "builder.eigenphi.io",
-        "supported-apis": ["v0.1"]
+        "supported-apis": [
+            "v0.1"
+        ]
     },
     {
         "name": "Gambit Labs",
         "rpc": "https://builder.gmbit.co/rpc",
-        "supported-apis": ["refund-recipient"]
+        "supported-apis": [
+            "refund-recipient"
+        ]
     },
     {
         "name": "payload",
         "rpc": "rpc.payload.de",
-        "supported-apis": ["refund-recipient"]
+        "supported-apis": [
+            "refund-recipient"
+        ]
     },
     {
         "name": "Loki",
         "rpc": "rpc.lokibuilder.xyz",
-        "supported-apis": ["refund-recipient"]
+        "supported-apis": [
+            "refund-recipient"
+        ]
     },
     {
         "name": "JetBuilder",
         "rpc": "rpc.mevshare.jetbldr.xyz",
-        "supported-apis": ["refund-recipient", "cancel-endpoint"]
+        "supported-apis": [
+            "refund-recipient",
+            "cancel-endpoint"
+        ]
     },
     {
         "name": "tbuilder",
         "rpc": "flashbots.rpc.tbuilder.xyz",
-        "supported-apis": ["refund-recipient"]
+        "supported-apis": [
+            "refund-recipient"
+        ]
     },
     {
         "name": "bobthebuilder",
         "rpc": "rpc.bobthebuilder.xyz",
-        "supported-apis": ["v0.1"]
+        "supported-apis": [
+            "v0.1"
+        ]
     },
     {
         "name": "BTCS",
         "rpc": "flashbots.btcs.com",
-        "supported-apis": ["v0.1"]
+        "supported-apis": [
+            "v0.1"
+        ]
     },
     {
         "name": "bloXroute",
         "rpc": "rpc-builder.blxrbdn.com",
-        "supported-apis": ["v0.1"]
+        "supported-apis": [
+            "v0.1"
+        ]
     },
     {
         "name": "Blockbeelder",
         "rpc": "https://blockbeelder.com/rpc",
-        "supported-apis": ["refund-recipient", "cancel-empty-bundle"]
+        "supported-apis": [
+            "refund-recipient",
+            "cancel-empty-bundle"
+        ]
     },
     {
         "name": "Quasar",
         "rpc": "rpc.quasar.win",
-        "supported-apis": ["refund-recipient", "cancel-endpoint"]
+        "supported-apis": [
+            "refund-recipient",
+            "cancel-endpoint"
+        ]
     },
     {
         "name": "Eureka",
         "rpc": "rpc.eurekabuilder.xyz",
-        "supported-apis": ["refund-recipient", "cancel-endpoint"]
+        "supported-apis": [
+            "refund-recipient",
+            "cancel-endpoint"
+        ]
+    },
+    {
+        "name": "ethbuilder",
+        "rpc": "https://rpc.ethbuilder.org",
+        "supported-apis": [
+            "v0.1"
+        ]
     }
 ]


### PR DESCRIPTION
## Summary

Adds an entry for **ethbuilder** to `builder-registrations.json`.

- **Builder name:** ethbuilder
- **RPC:** https://rpc.ethbuilder.org
- **Supported APIs:** `v0.1`
- **On-chain `extra_data`:** `ethbuilder.org/0.1`
- **Operator contact:** [@tradezermind](https://github.com/tradezermind) on GitHub | [@Ethbuilder_org](https://t.me/Ethbuilder_org) on Telegram
- **Stack:** rbuilder + Reth on a dedicated bare-metal node in Nuremberg.
  Currently bidding into Aestus, Agnostic, ETHGas, Flashbots, Titan, and
  Ultrasound mainnet relays. Block share is below the 2 % criterion right
  now; this PR is to signal intent and compatibility, per the README:
  > _The purpose of this registry is to signal intent, compatibility,
  > and agreement with the principles._

## Fair Market Principles attestation

The ethbuilder operator commits to the Fair Market Principles in
`fair-market-principles.md`. Specifically:

- Bundles received from MEV-share matchmakers will not be sold or shared
  with other parties (no other builders, no internal or external
  searchers).
- Bundle atomicity will be preserved: either all transactions land in
  the intended order or none do. The only exception is opt-in
  conflict-free merging where the user has consented.
- Bundle privacy (including failed-trade privacy) will be respected;
  no sensitive bundle data will be shared outside the builder.
- Validity conditions will be correctly implemented, including correct
  refund transfers to the configured recipients (the upstream rbuilder
  implementation is used unmodified for this).
- We will not take actions that negatively impact bundle execution
  quality (price or refund amount).
- The default rbuilder merge-ordering algorithms `mp-ordering` and
  `parallel-builder` are in use without modification. Public
  documentation of the merging logic will be published once the ops
  dashboard is live.

## Reachability

```
$ curl -X POST -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"eth_sendBundle","params":[]}' \
  https://rpc.ethbuilder.org/
{"jsonrpc":"2.0","result":null,"id":1}

$ curl -X POST https://rpc.ethbuilder.org/health
ok
```

TLS via Let's Encrypt (expires Aug 12, 2026). Body size capped at 1 MB.
Only POST accepted; GET returns 405.

## Builder pubkey

`0x8c364c0bc834d517d90110cc6395901c136a3e102ced351c11318d7e48c7fe4289e816369c7b78ab5e8a539ee0614784`