### PR TITLE
Add Bombora

### DIFF
--- a/builder-registrations.json
+++ b/builder-registrations.json
@@ -88,5 +88,10 @@
         "name": "Eureka",
         "rpc": "rpc.eurekabuilder.xyz",
         "supported-apis": ["refund-recipient", "cancel-endpoint"]
+    },
+    {
+        "name": "Bombora",
+        "rpc": "rpc.bombora.build",
+        "supported-apis": ["refund-recipient", "cancel-endpoint"]
     }
 ]


### PR DESCRIPTION
Registers Bombora as a builder.

- Name: Bombora
- RPC: rpc.bombora.build
- Supported APIs: refund-recipient, cancel-endpoint

Bombora attests that we agree to the Fair Market Principles outlined in `fair-market-principles.md`.