### PR TITLE
Register Bear builder

### DIFF
--- a/builder-registrations.json
+++ b/builder-registrations.json
@@ -93,5 +93,10 @@
         "name": "Bombora",
         "rpc": "rpc.bombora.build",
         "supported-apis": ["refund-recipient", "cancel-endpoint"]
+    },
+    {
+        "name": "Bear",
+        "rpc": "https://rpc.bearmev.com",
+        "supported-apis": ["refund-recipient", "cancel-endpoint"]
     }
 ]


### PR DESCRIPTION
## Register Bear

Adding Bear to the builder registrations.

- **Name:** Bear
- **RPC:** https://rpc.bearmev.com
- **Supported APIs:** refund-recipient, cancel-endpoint

Bear is an independent Ethereum block builder running rbuilder with counter-MEV protection. Bear has delivered 50+ blocks to proposers via Flashbots, Ultra Sound, Aestus, and Titan relays.

**Builder pubkey:** `0xb5a9acce9a395a642d8deb5d85ffc3a5639c3bc1224c729b7a7ff71897deec6ba37f4f74b7de76caa3265c3686f28af7`

**Fee recipient:** `0xe40953d7f29dfa7396ae4822554548650afa76bf`

We attest that we agree to the Fair Market Principles outlined in fair-market-principles.md.